### PR TITLE
Adding functionality to build and prepare lecture notes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build directories
+output/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+notes:
+	mkdir -p output && pdflatex --output-dir=output src/notes.tex
+all:
+	@echo "Makefile needs your attention"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Tor Under the hood
+
+## Description
+
+**Tor under the hood** is a technical talk prepared and given by Mr. Jaysinh
+Shukla. This repository contains the source of slides and lecture notes.
+
+## Requirements
+
+* [npm][npm]
+* [LaTeX PDF parser][latex]
+* [GNU/Make][make]
+
+## Build
+
+* **Build Notes:**
+
+  The command `make notes` will build the notes at `output` directory of the
+  project. The notes will be in *PDF* format.
+
+[npm]: https://www.npmjs.com
+[latex]: https://www.latex-project.org/
+[make]: https://www.gnu.org/software/make/

--- a/src/notes.tex
+++ b/src/notes.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\title{Lecture notes of Tor under the hood}
+\author{Jaysinh Shukla}
+\begin{document}
+
+\maketitle
+
+\end{document}


### PR DESCRIPTION
The command `make notes` will build the lecture notes at *output*
directory of the project. The output format is *PDF*.